### PR TITLE
Fix #4 - Add option-var to set the output file

### DIFF
--- a/flycheck-elm.el
+++ b/flycheck-elm.el
@@ -105,6 +105,23 @@
    (lambda (x)(equal (flycheck-elm-decode-type x) type))
    lst))
 
+(flycheck-def-option-var flycheck-elm-output-file nil elm
+  "The output file to compile to when performing syntax checking.
+
+The value of this variable is either nil, or a string with the
+path to the desired compilation output file.
+
+If nil, flycheck-elm will compile to null-device so as to not
+interfere with your project files.
+
+If a string is provided, the flycheck-elm will compile your code
+to the given file each time it performs syntax checking. This can
+be set to any file with a .js or .html extension. Please note
+that the contents of this file will be overwritten every time
+flycheck-elm successfully compiles your Elm code."
+  :type '(string))
+
+
 (flycheck-def-option-var flycheck-elm-main-file nil elm
   "A main elm file for flycheck-elm to compile instead of individual files.
 
@@ -115,22 +132,11 @@ project. The main elm file is the .elm file which contains a
 \"main\" function, for example: \"Main.elm\")."
   :type '(string))
 
-(flycheck-def-option-var flycheck-elm-output-file "index.html" elm
-  "The output file to compile to when performing syntax checking.
-
-The value of this variable is passed as the --ouput argument to
-elm-make whenever flycheck-elm performs syntax checking. This
-defaults to index.html, but can be set to any file with a .js or
-.html extension. Please note that the contents of this file will
-be overwritten every time flycheck-elm successfully compiles
-your Elm code."
-  :type '(string))
-
 (flycheck-define-checker elm
   "A syntax checker for elm-mode using the json output from elm-make"
   :command ("elm-make" "--report=json"
-            (eval (concat "--output=" flycheck-elm-output-file))
-            (eval (or flycheck-elm-main-file buffer-file-name)))
+            (eval (or flycheck-elm-main-file buffer-file-name))
+            (eval (concat  "--output=" (eval (or flycheck-elm-output-file null-device)))))
   :error-parser flycheck-elm-parse-errors
   :modes elm-mode)
 

--- a/flycheck-elm.el
+++ b/flycheck-elm.el
@@ -115,9 +115,21 @@ project. The main elm file is the .elm file which contains a
 \"main\" function, for example: \"Main.elm\")."
   :type '(string))
 
+(flycheck-def-option-var flycheck-elm-output-file "index.html" elm
+  "The output file to compile to when performing syntax checking.
+
+The value of this variable is passed as the --ouput argument to
+elm-make whenever flycheck-elm performs syntax checking. This
+defaults to index.html, but can be set to any file with a .js or
+.html extension. Please note that the contents of this file will
+be overwritten every time flycheck-elm successfully compiles
+your Elm code."
+  :type '(string))
+
 (flycheck-define-checker elm
   "A syntax checker for elm-mode using the json output from elm-make"
   :command ("elm-make" "--report=json"
+            (eval (concat "--output=" flycheck-elm-output-file))
             (eval (or flycheck-elm-main-file buffer-file-name)))
   :error-parser flycheck-elm-parse-errors
   :modes elm-mode)


### PR DESCRIPTION
This change adds an option-var for setting the file to be passed as
the --output argument to elm-make whenever flycheck-elm is run.

The file defaults to index.html, the current default for elm-make.
