### PR TITLE
Use flycheck's new :default-directory option to handle projects with subdirs

### DIFF
--- a/flycheck-elm.el
+++ b/flycheck-elm.el
@@ -3,7 +3,7 @@
 ;; Copyright (c) 2015 Brian Sermons
 
 ;; Author: Brian Sermons
-;; Package-Requires: ((flycheck "0.24") (emacs "24.4"))
+;; Package-Requires: ((flycheck "0.29-cvs") (emacs "24.4"))
 ;; URL: https://github.com/bsermons/flycheck-elm
 
 ;; This file is not part of GNU Emacs.
@@ -108,6 +108,10 @@
    (lambda (x)(equal (flycheck-elm-decode-type x) type))
    lst))
 
+(defun flycheck-elm-package-json-directory (&optional checker)
+  "Find the directory in which CHECKER should run \"elm-make\"."
+  (locate-dominating-file default-directory "elm-package.json"))
+
 (flycheck-def-option-var flycheck-elm-output-file nil elm
   "The output file to compile to when performing syntax checking.
 
@@ -144,6 +148,8 @@ project. The main elm file is the .elm file which contains a
             (eval (or flycheck-elm-main-file buffer-file-name))
             (eval (concat  "--output=" (or flycheck-elm-output-file "/dev/null"))))
   :error-parser flycheck-elm-parse-errors
+  :default-directory flycheck-elm-package-json-directory
+  :predicate flycheck-elm-package-json-directory
   :modes elm-mode)
 
 ;;;###autoload


### PR DESCRIPTION
This enables the checker if and only if an existing elm-package.json can be found, and runs elm-make from the directory of that file.

The previous behaviour of allowing elm-make to implicitly create elm-package.json in the current directory - which could cause the checker initialisation to hang - is also therefore avoided. Initial invocation of elm-make is best carried out interactively, rather than implicitly.

Fixes #3, but is pending the next flycheck release: 0.29. This code works with the current MELPA snapshot package though, so you might consider committing this already, then not tagging a new stable version of flycheck-elm until the next flycheck stable release has been made.
