### PR TITLE
:default-directory should have been :working-directory

### DIFF
--- a/flycheck-elm.el
+++ b/flycheck-elm.el
@@ -151,7 +151,7 @@ project. The main elm file is the .elm file which contains a
             (eval (or flycheck-elm-main-file buffer-file-name))
             (eval (concat  "--output=" (or flycheck-elm-output-file "/dev/null"))))
   :error-parser flycheck-elm-parse-errors
-  :default-directory flycheck-elm-package-json-directory
+  :working-directory flycheck-elm-package-json-directory
   :predicate flycheck-elm-package-json-directory
   :modes elm-mode)
 


### PR DESCRIPTION
Sorry - this was an oversight in my previous PR (#10, fix for #3), which I think would have effectively been a no-op.
