### PR TITLE
Support no json edge case

### DIFF
--- a/flycheck-elm-tests.el
+++ b/flycheck-elm-tests.el
@@ -103,6 +103,29 @@
     (should (= 1 (length (flycheck-elm-filter-by-preference all 'warn-after-errors))))
     (should (= 7 (length (flycheck-elm-filter-by-preference warnings 'warn-after-errors))))))
 
+(ert-deftest test-plain-line-numbers ()
+  "Insure the line number is parsed correctly"
+  (let ((line "55| getMore : Thing -> More"))
+    (should (= 55 (progn
+                    (string-match flycheck-elm-plain-regex-line-number line)
+                    (flycheck-elm-plain-line-number line))))))
+
+(ert-deftest test-plain-columns ()
+  "Insure the column numbers are parsed correctly"
+  (let ((line "    ^^^^"))
+    (should (equal (cons 5 8) (progn
+                                (string-match flycheck-elm-plain-regex-columns line)
+                                (flycheck-elm-plain-columns))))))
+
+(ert-deftest test-plain-tag ()
+  "Insure the title tag is parsed correctly"
+  (let ((line "-- SYNTAX PROBLEM ----------------------- Main.elm"))
+    (should (equal
+             (progn
+               (string-match flycheck-elm-plain-regex-tag line)
+               (flycheck-elm-plain-tag line))
+             "SYNTAX PROBLEM"))))
+
 ;; Example errors
 
 (setq single-error  "[{\"subregion\":null,\"suggestions\":[],\"details\":\"\",\"region\":{\"end\":{\"column\":12,\"line\":3},\"start\":{\"column\":8,\"line\":3}},\"type\":\"error\",\"file\":\"Sample.elm\",\"tag\":\"NAMING ERROR\",\"overview\":\"Cannot find variable `text`\"}]")

--- a/flycheck-elm.el
+++ b/flycheck-elm.el
@@ -169,18 +169,18 @@ Construct the properties line number 'L, column number C and the message M."
      ;; Grab title
      ((string-match flycheck-elm-plain-regex-tag line)
       (let ((tag (flycheck-elm-plain-tag line)))
-        (flycheck-elm-plain-message rest l c (concat "[" tag "]" m))))
+        (flycheck-elm-plain-parse-data rest l c (concat "[" tag "]" m))))
      ;; Grab column data
      ((string-match flycheck-elm-plain-regex-columns line)
       (let ((columns (flycheck-elm-plain-columns)))
-        (flycheck-elm-plain-message rest l (car columns) m)))
+        (flycheck-elm-plain-parse-data rest l (car columns) m)))
      ;; Grab line number
      ((string-match flycheck-elm-plain-regex-line-number line)
       (let ((line-number (flycheck-elm-plain-line-number line)))
-        (flycheck-elm-plain-message rest line-number c m)))
+        (flycheck-elm-plain-parse-data rest line-number c m)))
      ;; Otherwise concat current line onto the message with a newline between
      (t
-      (flycheck-elm-plain-message rest l c (concat m "\n" line))))))
+      (flycheck-elm-plain-parse-data rest l c (concat m "\n" line))))))
 
 (defun flycheck-elm-plain-parse-error (output checker buffer)
   "Decode elm regular OUTPUT errors from CHECKER in BUFFER.

--- a/flycheck-elm.el
+++ b/flycheck-elm.el
@@ -141,7 +141,7 @@ Uses previously completed `flycheck-elm-plain-regex-columns' match."
 
 (defun flycheck-elm-plain-line-number (line)
   "Grab match data for line number in LINE.
-Uses previously completed `flycheck-elm-plain-regex-row' match."
+Uses previously completed `flycheck-elm-plain-regex-line-number' match."
   (flycheck-string-to-number-safe (match-string 1 line)))
 
 (defun flycheck-elm-plain-tag (line)
@@ -176,8 +176,8 @@ Construct the properties line number 'L, column number C and the message M."
         (flycheck-elm-plain-message rest l (car columns) m)))
      ;; Grab line number
      ((string-match flycheck-elm-plain-regex-line-number line)
-      (let ((row (flycheck-elm-plain-line-number line)))
-        (flycheck-elm-plain-message rest row c m)))
+      (let ((line-number (flycheck-elm-plain-line-number line)))
+        (flycheck-elm-plain-message rest line-number c m)))
      ;; Otherwise concat current line onto the message with a newline between
      (t
       (flycheck-elm-plain-message rest l c (concat m "\n" line))))))


### PR DESCRIPTION
So I had trouble fitting in flycheck-elm-parse-error-data. This branch uses flycheck-elm-read-json directly in flycheck-elm-parse-errors. So I moved the let expression with `(json-array-type 'list)` to flycheck-elm-read-json.

In flycheck-elm-parse-errors, first check for valid json if so do everything the normal way. If that case fails, check for elm-make to emit success message, if not decode the plain message for row and column data if available. In some messages the location data is not available so I defaulted to 0,0. Build the message while parsing the data out and then return a list with the single edge case error emitted by elm-make. The last case is no errors, and returns nil.

Oh and I prefixed all the code to handle the edge case under `flycheck-elm-plain`.
